### PR TITLE
wasm: remove the gap between rust and cpp test code for logging

### DIFF
--- a/test/extensions/bootstrap/wasm/test_data/logging_cpp.cc
+++ b/test/extensions/bootstrap/wasm/test_data/logging_cpp.cc
@@ -27,7 +27,7 @@ extern "C" PROXY_WASM_KEEPALIVE uint32_t proxy_on_configure(uint32_t, uint32_t c
 extern "C" PROXY_WASM_KEEPALIVE void proxy_on_context_create(uint32_t, uint32_t) {}
 
 extern "C" PROXY_WASM_KEEPALIVE uint32_t proxy_on_vm_start(uint32_t, uint32_t) {
-  proxy_set_tick_period_milliseconds(10);
+  proxy_set_tick_period_milliseconds(5000);
   return 1;
 }
 

--- a/test/extensions/bootstrap/wasm/test_data/logging_rust.rs
+++ b/test/extensions/bootstrap/wasm/test_data/logging_rust.rs
@@ -1,6 +1,7 @@
 use log::{debug, error, info, trace, warn};
 use proxy_wasm::traits::{Context, RootContext};
 use proxy_wasm::types::LogLevel;
+use std::time::Duration;
 
 #[no_mangle]
 pub fn _start() {
@@ -12,6 +13,7 @@ struct TestRoot;
 
 impl RootContext for TestRoot {
     fn on_vm_start(&mut self, _: usize) -> bool {
+        self.set_tick_period(Duration::from_secs(5));
         true
     }
 


### PR DESCRIPTION
I'm still not sure why this causes the failure only for WAVM, but this hostcall only exists in cpp. We are fine for Rust as it is now